### PR TITLE
Feat/add columns to product manpower

### DIFF
--- a/lib/preco_certo/company.rb
+++ b/lib/preco_certo/company.rb
@@ -9,7 +9,7 @@ class Company < DataParse
   end
 
   def create(id, name, tax_regime, phone, cnpj, icms, ipi, pis, cofins)
-    CSV.open(file, "a", options) do |csv|
+    CSV.open(file, "a", **options) do |csv|
       csv << []
       csv << [id, name, tax_regime, phone, cnpj, icms, ipi, pis, cofins]
     end

--- a/lib/preco_certo/data_parse.rb
+++ b/lib/preco_certo/data_parse.rb
@@ -11,11 +11,11 @@ class DataParse
   end
 
   def parse!
-    CSV.read(file, options)
+    CSV.read(file, **options)
   end
 
   def create(attributes)
-    CSV.open(@file, "a", options) do |csv|
+    CSV.open(@file, "a", **options) do |csv|
       csv << attributes
     end
   end

--- a/lib/preco_certo/products_manpower.rb
+++ b/lib/preco_certo/products_manpower.rb
@@ -4,15 +4,17 @@ require "preco_certo/data_parse"
 
 # class ProductManPower, CSV products_manpower
 class ProductManPower
-  attr_accessor :id_product, :operation, :employee, :salary, :time, :cost_mo
+  attr_accessor :id_product, :operation, :employee, :salary, :time, :cost_mo, :type_operation, :id_equipment
 
-  def initialize(id_product, operation, employee, salary, time, cost_mo)
+  def initialize(id_product, operation, employee, salary, time, cost_mo, type_operation, id_equipment)
     @id_product = id_product
     @operation = operation
     @employee = employee
     @salary = salary
     @time = time
     @cost_mo = cost_mo
+    @type_operation = type_operation
+    @id_equipment = id_equipment
   end
 
   def self.productsmanpower
@@ -24,12 +26,14 @@ class ProductManPower
         line["employee"],
         line["salary"],
         line["time"],
-        line["cost_mo"]
+        line["cost_mo"],
+        line["type_operation"],
+        line["id_equipment"]
       )
     end
   end
 
-  def self.create(id_product, operation, employee, salary, time, cost_mo)
-    ProductManPower.new(id_product, operation, employee, salary, time, cost_mo)
+  def self.create(id_product, operation, employee, salary, time, cost_mo, type_operation, id_equipment)
+    ProductManPower.new(id_product, operation, employee, salary, time, cost_mo, type_operation, id_equipment)
   end
 end

--- a/lib/preco_certo/products_manpower.rb
+++ b/lib/preco_certo/products_manpower.rb
@@ -17,7 +17,7 @@ class ProductManPower
     @id_equipment = id_equipment
   end
 
-  def self.productsmanpower
+  def self.all
     data_parse = DataParse.new("preco_certo/storage/products_manpower.csv").parse!
     data_parse.each do |line|
       ProductManPower.new(

--- a/lib/preco_certo/storage/products_manpower.csv
+++ b/lib/preco_certo/storage/products_manpower.csv
@@ -1,11 +1,11 @@
-id_product;operation;employee;salary;time;cost_mo
-1;Colocar Carroceria;Luciano Paulista;1700.00;20.50;2.64
-1;Colocar Portas;Lucas Pol;1.600,00;15.5;1.88
-1;Colocar Motor;Lucas Araújo;1.650,00;12.5;1.56
-1;Colocar Painel;Marco Castro;2.000,00;9.5;1.44
-1;Colocar Rodas;Levi Silva;1.700,00;7.5;0.97
-2;Colocar Carroceria;Luciano Paulista;1700.00;20.50;2.64
-2;Colocar Portas;Lucas Pol;1.600,00;15.5;1.88
-2;Colocar Motor;Lucas Araújo;1.650,00;12.5;1.56
-2;Colocar Painel;Marco Castro;2.000,00;9.5;1.44
-2;Colocar Rodas;Levi Silva;1.700,00;7.5;0.99
+id_product;operation;employee;salary;time;cost_mo;type_operation;id_equipment
+1;Colocar Carroceria;Luciano Paulista;1700.00;20.50;2.64;0;1
+1;Colocar Portas;Lucas Pol;1.600,00;15.5;1.88;1;4
+1;Colocar Motor;Lucas Araújo;1.650,00;12.5;1.56;0;2
+1;Colocar Painel;Marco Castro;2.000,00;9.5;1.44;0;13
+1;Colocar Rodas;Levi Silva;1.700,00;7.5;0.97;1;5
+2;Colocar Carroceria;Luciano Paulista;1700.00;20.50;2.64;0;1
+2;Colocar Portas;Lucas Pol;1.600,00;15.5;1.88;1;2
+2;Colocar Motor;Lucas Araújo;1.650,00;12.5;1.56;0;4
+2;Colocar Painel;Marco Castro;2.000,00;9.5;1.44;1;4
+2;Colocar Rodas;Levi Silva;1.700,00;7.5;0.99;0;1

--- a/spec/products_manpower_spec.rb
+++ b/spec/products_manpower_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "Product_ManPower" do
-  let(:productsmanpowers) { ProductManPower.productsmanpower }
+  let(:productsmanpowers) { ProductManPower.all }
 
   it "create ProductManPower" do
     product_manpower = ProductManPower.create(6, "Montagem dos Bancos", "Luciano Paulista",

--- a/spec/products_manpower_spec.rb
+++ b/spec/products_manpower_spec.rb
@@ -4,13 +4,16 @@ RSpec.describe "Product_ManPower" do
   let(:productsmanpowers) { ProductManPower.productsmanpower }
 
   it "create ProductManPower" do
-    product_manpower = ProductManPower.create(6, "Montagem dos Bancos", "Luciano Paulista", "1200.00", 8.50, 15.50)
+    product_manpower = ProductManPower.create(6, "Montagem dos Bancos", "Luciano Paulista",
+                                              "1200.00", 8.50, 15.50, 0, 10)
     expect(product_manpower.id_product).to eq(6)
     expect(product_manpower.operation).to eq("Montagem dos Bancos")
     expect(product_manpower.employee).to eq("Luciano Paulista")
     expect(product_manpower.salary).to eq("1200.00")
     expect(product_manpower.time).to eq(8.50)
     expect(product_manpower.cost_mo).to eq(15.50)
+    expect(product_manpower.type_operation).to eq(0)
+    expect(product_manpower.id_equipment).to eq(10)
   end
 
   it "get all products_manpower" do

--- a/spec/products_manpower_spec.rb
+++ b/spec/products_manpower_spec.rb
@@ -27,5 +27,7 @@ RSpec.describe "Product_ManPower" do
     expect(productsmanpowers.first["salary"]).to eq("1700.00")
     expect(productsmanpowers.first["time"]).to eq("20.50")
     expect(productsmanpowers.first["cost_mo"]).to eq("2.64")
+    expect(productsmanpowers.first["type_operation"]).to eq("0")
+    expect(productsmanpowers.first["id_equipment"]).to eq("1")
   end
 end


### PR DESCRIPTION
Adiciona as colunas `type_operation` e `id_equipment` em `ProductsManpower` e corrige warnings de keyword parameters.

Closes #50